### PR TITLE
30 update blc up to use bluecore branding and themes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,14 @@ RUN gem install bundler:${BUNDLER_VERSION}
 
 COPY Gemfile Gemfile.lock ./
 
-RUN gem update --system && bundle install && \
-      rm -rf ${BUNDLE_PATH}/cache/*.gem && \
-      find ${BUNDLE_PATH}/ -name "*.c" -delete && \
-      find ${BUNDLE_PATH}/ -name "*.o" -delete
+# Only run bundle install if not using local gems
+RUN if [ "$USE_LOCAL_GEMS" != "true" ]; then \
+  gem update --system && \
+  bundle install && \
+  rm -rf ${BUNDLE_PATH}/cache/*.gem && \
+  find ${BUNDLE_PATH}/ -name "*.c" -delete && \
+  find ${BUNDLE_PATH}/ -name "*.o" -delete; \
+  fi
 
 WORKDIR /app/cul-it/bcl-up_server-webapp
 COPY . .

--- a/Gemfile
+++ b/Gemfile
@@ -31,8 +31,16 @@ gem 'uglifier', '>= 1.3.0'
 
 ## Gems manually added to for qa and qa_server engines
 # Required gems for QA and linked data access
-# gem 'qa_server', '~> 8.0'
-gem 'bcl_up_server', git: 'https://github.com/cul-it/bcl-up_server', branch: 'main'
+##############################################################################
+## USE_LOCAL_GEMS is set when running "run_local_gems.sh".                  ##
+## Allows realtime development of bcl-up_server while container is running  ##
+##############################################################################
+if ENV["USE_LOCAL_GEMS"] == "true"
+  gem 'bcl_up_server', path: '/bcl-up_server'
+else
+  gem 'bcl_up_server', git: 'https://github.com/cul-it/bcl-up_server', branch: 'main'
+end
+
 gem 'linkeddata'
 gem 'psych', '~> 5.1'
 gem 'qa', '~> 5.10'

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,6 @@ source "scripts/log_utils.sh"
 ###############################################################################
 print_header "💻 Executing build.sh"
 
-print_msg "🛠️  Updating bcl_up_server gem from Git..."
-bundle update bcl_up_server
-
 compose_file=""
 environment="development"
 precompile_assets="false"

--- a/config/locales/bcl_up_server_container.en.yml
+++ b/config/locales/bcl_up_server_container.en.yml
@@ -4,6 +4,6 @@ en:
     application_version: "0.1.0"
     application_name:  "Blue Core Lookup Service (BCL-UP)"
     footer:
-      copyright_html:  "<strong>Copyright &copy; 2018-2025 Cornell</strong> Licensed under the Apache License, Version 2.0"
+      copyright_html: "<strong>Copyright &copy; 2018-%{year} Cornell</strong> Licensed under the Apache License, Version 2.0"
       service_html:    A service of YOUR INSTITUTION.
       attribution_html: This service is supported by work on <a href="http://ld4p.org" class="navbar-link" target="_blank">Linked Data for Production</a> and <br>  <a href="https://wiki.duraspace.org/x/9xgRBg" class="navbar-link" target="_blank">Linked Data for Production</a> funded by <a href="https://mellon.org/" class="navbar-link" target="_blank">The Andrew W. Mellon Foundation</a>, <br>and by work on Questioning Authority in <a href="http://samvera.org" class="navbar-link" target="_blank">Samvera</a>, an open source community.

--- a/docker-compose-local-gems.yml
+++ b/docker-compose-local-gems.yml
@@ -1,0 +1,46 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - RAILS_ENV=development
+        - PRECOMPILE_ASSETS=false
+        - USE_LOCAL_GEMS=true
+    image: bcl-up-dev-local
+    container_name: bcl-up-dev-local
+    env_file: .env
+    environment:
+      - RAILS_ENV=development
+      - MAX_PERFORMANCE_CACHE_SIZE=33554432
+      - USE_LOCAL_GEMS=true
+    volumes:
+      - .env:/app/cul-it/bcl-up_server-webapp/.env:ro
+      - .:/app/cul-it/bcl-up_server-webapp
+      - ../bcl-up_server:/bcl-up_server
+    ports:
+      - "3000:3000"
+    depends_on:
+      - mysql
+    command: >
+      bash -c "bundle config set path 'vendor/bundle' &&
+               bundle install &&
+               bin/rails db:create db:migrate &&
+               bin/rails server -b 0.0.0.0"
+
+  mysql:
+    image: mariadb:10.6
+    restart: always
+    container_name: bcl-up-bcl_up_server-mysql-local
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_DATABASE=${MYSQL_DATABASE_NAME_PREFIX}_development
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+    ports:
+      - "${MYSQL_PORT:-3306}:3306"
+    volumes:
+      - db-mysql-data-local:/var/lib/mysql/data
+
+volumes:
+  db-mysql-data-local:

--- a/run_local_gems.sh
+++ b/run_local_gems.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+source "scripts/log_utils.sh"
+set -e
+
+###############################################################################
+##  Uses local gem `bcl_up_server` and rebuilds the Docker image             ##
+## ------------------------------------------------------------------------- ##
+## This allows for realtime local development of the bcl-up_server engine    ##
+###############################################################################
+print_header "💻 Executing run_local_gems.sh"
+
+print_msg "🐳  Composing Docker image to use local gem at '/bcl-up_server'..."
+docker compose -f docker-compose-local-gems.yml build --build-arg USE_LOCAL_GEMS=true
+
+print_msg "🐳  Starting Docker Image..."
+print_header "🚧 This uses the bcl-up_server gem from your local machine" "🛠️  Changes to the gem will be reflected real-time in app"
+docker compose -f docker-compose-local-gems.yml up
+

--- a/run_local_gems.sh
+++ b/run_local_gems.sh
@@ -14,5 +14,6 @@ docker compose -f docker-compose-local-gems.yml build --build-arg USE_LOCAL_GEMS
 
 print_msg "🐳  Starting Docker Image..."
 print_header "🚧 This uses the bcl-up_server gem from your local machine" "🛠️  Changes to the gem will be reflected real-time in app"
+print_header "⚙️  RUNNING BCL UP SERVER" "From bcl_up_server_container 🐳 image: $(< ./VERSION)"
 docker compose -f docker-compose-local-gems.yml up
 


### PR DESCRIPTION
### 🔧 Summary of Changes
* Added support for local gem development of bcl_up_server using a new docker-compose-local-gems.yml and run_local_gems.sh script.
* Updated the Dockerfile to conditionally skip bundle install when USE_LOCAL_GEMS=true is passed during build.
* Modified the Gemfile to load the gem from a local path when USE_LOCAL_GEMS is enabled.
* Cleaned up build.sh to remove unnecessary bundle update.
* Minor improvement to locale file to dynamically display current year in the footer.