### PR TITLE
fix: updated script to update bcl_up_server in docker instance when b…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/cul-it/bcl-up_server
-  revision: b41add839018c2cc1a953efe38dedb3c9891a40b
+  revision: 7e21d8dbdad945f847f339133baac900a9d0becc
   branch: main
   specs:
     bcl_up_server (1.0.2)
@@ -338,7 +338,7 @@ GEM
       ast (~> 2.4.1)
       racc
     parslet (2.0.0)
-    pkg-config (1.6.1)
+    pkg-config (1.6.2)
     prism (1.4.0)
     psych (5.2.3)
       date

--- a/build.sh
+++ b/build.sh
@@ -20,8 +20,14 @@ while getopts "pe:" options; do
   esac
 done
 
-print_msg "🛠️  Updating bcl_up_server gem from Git..."
-bundle update bcl_up_server
+## Ensure correct bcl_up_server gem is updated at install.
+print_msg "🛠️  Updating bcl_up_server gem from Git... inside Docker"
+docker build --target base -t bclup-temp-base -f Dockerfile .
+docker run --rm \
+  -v "$PWD":/app \
+  -w /app \
+  bclup-temp-base \
+  sh -c "bundle update bcl_up_server"
 
 if [ ${environment} == "development" ]; then
   export compose_file="docker-compose.yml"


### PR DESCRIPTION
updated bcl_up_server update logic so it always installs most up-to-date version of the gem without having to to a PR for container every time the gem is updated.